### PR TITLE
Allow more flexibility with full and relative cloud container urls

### DIFF
--- a/ios/CloudStore.swift
+++ b/ios/CloudStore.swift
@@ -63,6 +63,13 @@ class CloudStoreModule : RCTEventEmitter {
     }
 
     private func getFullICloudURL(_ relativePath: String, isDirectory dir: Bool = false) -> URL  {
+        
+        if let iCloudPath = iCloudURL?.path,
+            relativePath.starts(with: iCloudPath)
+        {
+            return URL(fileURLWithPath: relativePath, isDirectory: dir)
+        }
+        
         return iCloudURL!.appendingPathComponent(relativePath.rmPrefix("/"), isDirectory: dir)
     }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,6 +15,8 @@ if (Platform.OS === 'ios' && !CloudStore) {
 }
 const eventEmitter = new NativeEventEmitter(CloudStore);
 
+export const iCloudContainerPath = CloudStore.getConstants().iCloudContainerPath
+
 export function getConstants(): {
   iCloudContainerPath: string;
 } {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,12 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "esnext"
-  }
+  },
+  "exclude": [
+    "node_modules",
+    "babel.config.js",
+    "metro.config.js",
+    "jest.config.js",
+    "example"
+  ]
 }


### PR DESCRIPTION
When you read urls with `readDir`, you get back a full ICloudURL, not a relative one. When you try to use those URLs to read files, the url has too many iCloudURL components prefixed to it. Made small change to check if the url already has the iCloudPath in the beginning and skips appending if it does.
export iCloudContainerPath constant. update getFullICloudURL to not add icloud container path when already present. add excludes to tsconfig.json